### PR TITLE
Enabling advanced optimization in shadow

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,7 +2,8 @@
  :builds {:es5 {:target :node-script
                 :main main/main
                 :output-to "main-shadow-es5.js"
-                :compiler-options {:output-feature-set :es5}}
+                :compiler-options {:optimizations :advanced
+                                   :output-feature-set :es5}}
           :es6 {:target :node-script
                 :main main/main
                 :output-to "main-shadow-es6.js"


### PR DESCRIPTION
Sill

```
 ○ npx shadow-cljs compile es5 && node main-shadow-es5.js
shadow-cljs - config: /Users/ullrich/tmp/es5-inherits/shadow-cljs.edn
[:es5] Compiling ...
[:es5] Build completed. (83 files, 0 compiled, 0 warnings, 1,08s)
SHADOW import error /Users/ullrich/tmp/es5-inherits/.shadow-cljs/builds/es5/dev/out/cljs-runtime/goog.iter.es6.js

/Users/ullrich/tmp/es5-inherits/main-shadow-es5.js:385
      exports = moduleDef.call(undefined, exports);
                          ^
TypeError: $jscomp.inherits is not a function
    at /Users/ullrich/tmp/es5-inherits/.shadow-cljs/builds/es5/dev/out/cljs-runtime/goog/iter/es6.js:144:32
    at Object.goog.loadModule (/Users/ullrich/tmp/es5-inherits/main-shadow-es5.js:385:27)
    at /Users/ullrich/tmp/es5-inherits/.shadow-cljs/builds/es5/dev/out/cljs-runtime/goog/iter/es6.js:1:1
    at global.SHADOW_IMPORT (/Users/ullrich/tmp/es5-inherits/main-shadow-es5.js:64:44)
    at /Users/ullrich/tmp/es5-inherits/main-shadow-es5.js:1552:1
    at Object.<anonymous> (/Users/ullrich/tmp/es5-inherits/main-shadow-es5.js:1593:3)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
```